### PR TITLE
added type INTLONG to psf reader

### DIFF
--- a/pycircuit/post/cds/psf.py
+++ b/pycircuit/post/cds/psf.py
@@ -285,6 +285,7 @@ TYPECOMPLEXDOUBLE = 12
 TYPESTRUCT = 16
 TYPESTRING = 2 ## Incorrect number
 TYPEARRAY = 3 ## Incorrect number
+TYPEINTLONG = 5
 class DataTypeDef(Chunk):
     """Class representing data type of waveform data"""
     type=16
@@ -293,13 +294,15 @@ class DataTypeDef(Chunk):
         TYPEINTBYTE: Int8,
         TYPECOMPLEXDOUBLE: ComplexFloat64,
         TYPESTRING: String,
-        TYPEARRAY: Array
+        TYPEARRAY: Array,
+        TYPEINTLONG: Int32
     }
     PSFASCDict = {
         TYPEFLOATDOUBLE: "FLOAT DOUBLE",
         TYPEINTBYTE: "INT BYTE",
         TYPECOMPLEXDOUBLE: "COMPLEX DOUBLE",
-        TYPESTRING: "STRING *"
+        TYPESTRING: "STRING *",
+        TYPEINTLONG: "INT LONG"
     }
     
     def __init__(self, psf, id=0, name=None, datatypeid=0, structdef=None):


### PR DESCRIPTION
Hi,

I added a new type to the psf reader for reading 32 bit integers out of the psf data files. This was necessary for a data file of mine which means I verified that the read data is equivalent to the data which I can read with cadence wavescan.

Perhaps this is helpfull to anybody else one day.

Best regards

Horst
