### PR TITLE
MOS with symbolic toolkit

### DIFF
--- a/pycircuit/circuit/examples/mos_cir.py
+++ b/pycircuit/circuit/examples/mos_cir.py
@@ -1,0 +1,20 @@
+#This code finds the gain of a simple common-source amplifier stage, using symgolic toolkit.
+
+from sympy import *
+from pycircuit.circuit import *
+from pycircuit.circuit import mos
+c=SubCircuit(toolkit=symbolic)
+inp=c.add_node('inp')
+out=c.add_node('out')
+vdd=c.add_node('vdd')
+var('R1,gm1,s')
+c['VDD']=VS(vdd,gnd,v=5,vac=0)
+c['R1']=R(vdd,out,r=R1)
+c['Vin']=VS(inp,gnd,v=1,vac=1)
+c['M1']=mos.MOS(inp,out,gnd,gnd,gm=gm1,gds=0,gmb=0,toolkit=symbolic)
+ac=AC(c)
+res=ac.solve(s,complexfreq=True)
+gain=sympy.simplify(res.v('out')/res.v('inp'))
+print "The gain of the CS stage is:"
+sympy.pprint(gain)
+

--- a/pycircuit/circuit/examples/mos_cir_with_caps.py
+++ b/pycircuit/circuit/examples/mos_cir_with_caps.py
@@ -1,0 +1,23 @@
+#This code finds the gain of a CS stage, now considering the intrinsic MOS capacitantes. The results is the same as in the book Design Analog CMOS Integrated Circuits, by Behzad Razavi - pg 174.
+
+from sympy import *
+from pycircuit.circuit import *
+from pycircuit.circuit import mos
+c=SubCircuit(toolkit=symbolic)
+inp=c.add_node('inp')
+inp1=c.add_node('inp1')
+out=c.add_node('out')
+vdd=c.add_node('vdd')
+var('R_L,R_S,gm1,gmb1,ro1,Cgs1,Cgd1,Cdb1,s')
+c['VDD']=VS(vdd,gnd,v=5,vac=0)
+c['R_L']=R(vdd,out,r=R_L)
+c['R_S']=R(inp,inp1,r=R_S)
+c['Vin']=VS(inp,gnd,v=1,vac=1)
+c['M1']=mos.MOS(inp1,out,gnd,gnd,gm=gm1,gds=0,gmb=0,Cgs=Cgs1,Cgd=Cgd1,Cdb=Cdb1,toolkit=symbolic)
+ac=AC(c)
+res=ac.solve(s,complexfreq=True)
+gain=simplify(res.v('out')/res.v('inp'))
+print "\nThe transfer function of the CS stage is:"
+sympy.pprint(gain)
+print "\nShowing the denominator as polynomial:"
+sympy.pprint(denom(gain).as_poly(s))

--- a/pycircuit/circuit/mos.py
+++ b/pycircuit/circuit/mos.py
@@ -44,11 +44,13 @@ class MOS(SubCircuit):
 
         self['Igm'] = VCCS('g', 's', 
                            'd', 's', 
-                           gm=self.ipar.gm)
+                           gm=self.ipar.gm,
+                           toolkit=self.toolkit)
 
         self['Igmb'] = VCCS('b', 's', 
                             'd', 's', 
-                            gm=self.ipar.gmb)
+                            gm=self.ipar.gmb,
+                            toolkit=self.toolkit)
 
         self['gds'] = G('d', 's', 
                         g = self.ipar.gds, noisy = False)
@@ -103,11 +105,13 @@ class MOS_ACM(SubCircuit):
 
         self['Igm'] = VCCS('g', 's', 
                            'd', 's', 
-                           gm=self.ipar.gm)
+                           gm=self.ipar.gm,
+                           toolkit=self.toolkit)
 
         self['Igmb'] = VCCS('b', 's', 
                             'd', 's', 
-                            gm=self.ipar.gmb)
+                            gm=self.ipar.gmb,
+                            toolkit=self.toolkit)
 
         self['gds'] = G('d', 's', 
                         g = self.ipar.gds, noisy = False)

--- a/pycircuit/post/cds/cds.py
+++ b/pycircuit/post/cds/cds.py
@@ -13,7 +13,7 @@ def find_virtuoso():
 	if  virtuosocmd == None:
 		raise ValueError("Cannot find virtuoso executable")
 		
-	cmd = virtuosocmd + " -nograph"
+	cmd = virtuosocmd + " -nographE"
 	return cmd
 
 class CadenceSession(object):


### PR DESCRIPTION
This fixes allow to use MOS transistors with symbolic toolkit. Two examples showing it working are added as well.
